### PR TITLE
Add drag handlers for placing lines of Xs

### DIFF
--- a/src/components/GameLevel/Level.jsx
+++ b/src/components/GameLevel/Level.jsx
@@ -49,7 +49,8 @@ const Level = ({ id, level }) => {
   const completed = isLevelCompleted(Number(id));
 
   // Handle click on square
-  const handleClick = (row, col) => {
+  const handleClick = (row, col) => setBoard(board => {
+
     const currentValue = board[row][col];
 
     // Initialize newBoard as a copy of the current board
@@ -62,8 +63,6 @@ const Level = ({ id, level }) => {
     } else if (currentValue === "Q") {
       removeQueen(newBoard, row, col);
     }
-
-    setBoard(newBoard);
 
     // Check for win condition after updating the board
     if (checkWinCondition(newBoard, boardSize, colorRegions)) {
@@ -87,7 +86,9 @@ const Level = ({ id, level }) => {
       clashingPositions.map(({ row, col }) => `${row},${col}`)
     );
     setClashingQueens(clashingSet);
-  };
+
+    return newBoard;
+  });
 
   const getQueenPositionForGivenX = (xRow, xCol, newBoard) => {
     const directions = [

--- a/src/components/GameLevel/components/Square.jsx
+++ b/src/components/GameLevel/components/Square.jsx
@@ -9,6 +9,13 @@ const Square = ({ row, col, value, region, onClick, level, isClashing }) => {
   const colorRegions = levels[level].colorRegions;
   const regionColors = levels[level].regionColors;
 
+  const onDrag = (event) => {
+    const primaryButtonHeld = event.buttons & 1;
+    if (primaryButtonHeld && value === null) {
+      onClick();
+    }
+  }
+
   // Function to determine border classes
   const getBorderClasses = () => {
     const borderClasses = [];
@@ -43,6 +50,8 @@ const Square = ({ row, col, value, region, onClick, level, isClashing }) => {
     <div
       className={`square hover:brightness-75 ${borderClasses}`}
       onClick={onClick}
+      onMouseLeave={onDrag}
+      onMouseOver={onDrag}
       style={{
         backgroundColor: regionColors[region],
         color: isClashing ? "red" : "black",

--- a/src/components/GameLevel/components/Square.jsx
+++ b/src/components/GameLevel/components/Square.jsx
@@ -56,6 +56,7 @@ const Square = ({ row, col, value, region, onClick, level, isClashing }) => {
         backgroundColor: regionColors[region],
         color: isClashing ? "red" : "black",
       }}
+      draggable="false"
     >
       {value === "Q" ? <Queen /> : value === "X" ? <Cross /> : value}
     </div>


### PR DESCRIPTION
Closes #5 

This PR adds onMouseOver and onMouseLeave handlers to Square.js to implement the "drag to place Xs" behavior. It does this by checking whether the square is already empty and whether the user is holding down the primary mouse button.

<img src="https://github.com/user-attachments/assets/a9b14a4f-9a63-44d3-9cf6-769bd6a84313" alt="a gif demonstrating the drag behavior" width="400" />

Note that this also required a small refactor to Level.js—previously, if the user made two inputs in the same event handler tick, both inputs would use the same initial board state, and the second input would "win". This happens often when dragging, because the first `mouseover` event happens simultaneously with the first `mouseleave` event. In this case, the `mouseover` event will always win, and only one X will be checked.

In theory there's still a little bit of unsoundness here because we're reusing the current render cycle's version of `Square#value` after potentially updating it in `handleClick`, but in practice even when dragging extremely quickly I wasn't able to get this to cause any kind of issue, and fixing it would be more annoying (at least, it would require adding a new "clickIfUnoccupied" handler to the Level or a new function argument or something along those lines).

Finally, I had to fix a small bug that seems to be caused by React adding `dragstart` handlers to the element when I add an `onMouseLeave` property. Luckily, this was fixed with a one-line change to add `draggable="false"` to the element to prevent the default drag behavior.


