### PR TITLE
Fix level 80

### DIFF
--- a/src/utils/levels/level80.js
+++ b/src/utils/levels/level80.js
@@ -2,11 +2,11 @@ import {
   altoMain,
   anakiwa,
   bittersweet,
-  canCan,
   celadon,
   chardonnay,
-  lightWisteria,
-  nomad,
+  halfBaked,
+  lightOrchid,
+  lightWisteria
 } from "../colors";
 
 const level80 = {
@@ -19,16 +19,16 @@ const level80 = {
     ["A", "G", "F", "H", "H", "F", "C", "D"],
     ["A", "G", "F", "F", "F", "F", "G", "D"],
     ["A", "G", "G", "G", "G", "G", "G", "D"],
-    ["A", "G", "G", "G", "G", "D", "D", "D"],
+    ["A", "A", "A", "G", "G", "D", "D", "D"],
   ],
   regionColors: {
     A: lightWisteria,
     B: altoMain,
-    C: nomad,
+    C: halfBaked,
     D: bittersweet,
     E: anakiwa,
     F: celadon,
-    G: canCan,
+    G: lightOrchid,
     H: chardonnay,
   },
 };


### PR DESCRIPTION
Colors changes come from the image import tool in the level builder. Fixes the issue of the level permitting two solutions.

Closes #11 