### PR TITLE
#15: open winning screen in a new event loop

### DIFF
--- a/src/components/GameLevel/Level.jsx
+++ b/src/components/GameLevel/Level.jsx
@@ -71,7 +71,7 @@ const Level = ({ id, level }) => {
     // Check for win condition after updating the board
     if (checkWinCondition(newBoard, boardSize, colorRegions)) {
       if (!hasWon) {
-        setShowWinningScreen(true);
+        setTimeout(() => setShowWinningScreen(true), 0);
       }
       setHasWon(true);
       markLevelAsCompleted(Number(id));


### PR DESCRIPTION
Fix #15 by calling setShowWinningScreen inside setTimeout so it's not part of the same event.