### PR TITLE
fix(winningScreen): solve time text color

### DIFF
--- a/src/components/GameLevel/components/WinningScreen.jsx
+++ b/src/components/GameLevel/components/WinningScreen.jsx
@@ -87,7 +87,7 @@ const WinningScreen = ({ timer, previousLevel, nextLevel, level, close }) => {
               alt="Golden chiclet background"
               className="rounded w-full h-16 object-cover"
             />
-            <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 text-foreground">
+            <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 text-black">
               <div className="text-lg">{formatDuration(timer)}</div>
               <div className="font-medium text-sm">Solve time</div>
             </div>


### PR DESCRIPTION
I didn't realize before that the "Solve time" color is based on the text-foreground, which in the dark theme is white. So it looks like this:
![image](https://github.com/user-attachments/assets/790e1ae6-ff6c-4f79-9af1-35b92b46dd15)
