### PR TITLE
357: Updated the bg color for the show available levels toggle

### DIFF
--- a/src/components/LevelSelection/components/AvailableLevelsFilter.jsx
+++ b/src/components/LevelSelection/components/AvailableLevelsFilter.jsx
@@ -20,7 +20,7 @@ const AvailableLevelsFilter = ({ checked, disabled, handleChange }) => {
       <div className="relative ml-2 group">
         <QuestionIcon />
         {!disabled && (
-          <span className="absolute top-5 right-0 text-xs min-w-40 bg-white p-2 rounded-md border-2 border-slate-300 z-10 hidden group-hover:flex">
+          <span className="absolute top-5 right-0 text-xs min-w-40 bg-white dark:bg-gray-800 p-2 rounded-md border-2 border-slate-300 z-10 hidden group-hover:flex">
             I've added as many levels as I could find. I'd appreciate any help
             in finding the rest.
           </span>


### PR DESCRIPTION
Issue info: 357 -  updated the background color of "show available levels" to gray-800 in dark mode.

![Screenshot 2025-03-15 231114](https://github.com/user-attachments/assets/4fef2bf5-f32f-4944-8848-b06d27bcd935)
![Screenshot 2025-03-15 231142](https://github.com/user-attachments/assets/219cba4b-bd54-4f89-9bf0-d37843a1fcbb)
