### PR TITLE
Dynamic i18n

### DIFF
--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -1,41 +1,47 @@
+/*
+ * This file now automatically detects all language JSON files in the directory.
+ * To add a new language, simply create a new [language-code].json file in this directory.
+ * For example: fr.json for French, de.json for German, etc.
+ * There is no need to modify this file to add new languages.
+ */
+
 import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
-import enJson from "./en.json";
-import itJson from "./it.json";
-import esJson from "./es.json";
-import arJson from "./ar.json";
-import ptJson from "./pt.json";
 import LanguageDetector from "i18next-browser-languagedetector";
 
-const resources = {
-  es: {
-    translation: esJson,
-  },
-  en: {
-    translation: enJson,
-  },
-  it: {
-    translation: itJson,
-  },
-  ar: {
-    translation: arJson,
-  },
-  pt: {
-    translation: ptJson,
-  },
-};
+// Import language JSON files using Vite's dynamic imports
+const modules = import.meta.glob('./*.json', { eager: true });
+
+// Dynamically build the resources object
+const resources = {};
+Object.entries(modules).forEach(([path, module]) => {
+  // Extract the language code from the path (e.g., './en.json' -> 'en')
+  const langCode = path.match(/\.\/(.+)\.json$/)[1];
+  resources[langCode] = {
+    translation: module.default || module
+  };
+});
+
+// Define the primary language and fallback order
+const primaryLanguage = "en";
+const languageCodes = Object.keys(resources);
+const fallbackLanguages = [primaryLanguage, ...languageCodes.filter(code => code !== primaryLanguage)];
 
 i18n
   .use(initReactI18next)
   .use(LanguageDetector)
   .init({
     resources,
-    fallbackLng: ["en", "it", "es", "ar", "pt"],
+    fallbackLng: fallbackLanguages,
     interpolation: {
       escapeValue: false,
     },
-    supportedLngs: Object.keys(resources),
+    supportedLngs: languageCodes,
     detection: {
       convertDetectedLanguage: (lng) => lng.split("-")[0], // remove it if you want support regional languages (en -> en-US)
     },
   });
+
+// Export i18n for use in the application
+export default i18n;
+


### PR DESCRIPTION
Hi, I have set the i18n index to be dynamic so that by simply saving a new language json to the corresponding folder, the system will detect it and display the new language in the language dropdown menu... you can try adding the fr.json file to the directory and see the change in the game panel...

[fr.json](https://github.com/user-attachments/files/20149822/fr.json)

I've automatically translated it... I don't speak French, and the languages ​​I do know are, apart from some already existing in the system, official secondary languages ​​such as Basque, Catalan, etc... which are governed by BCP 47 instead of ISO-3166 and it's more complicated to get the flags for the drop-down menu...

This pull request aims to make internationalizing the game even easier by simply placing a new json, making the rest of the i18n system automatic.