### PR TITLE
fix dateFormat at bonus levels #495

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,5 +1,6 @@
 {
   "LANGUAGE_NAME": "English",
+  "DATE_FORMAT": "MMM d, yyyy",
   "LEVEL": "Level",
   "AVAILABLE_LEVELS_ONLY": "Available levels only",
   "HELP_IN_FINDING_NEW_LEVELS": "I've added as many levels as I could find. I'd appreciate any help in finding the rest.",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1,5 +1,6 @@
 {
   "LANGUAGE_NAME": "Español",
+  "DATE_FORMAT": "dd 'de' MMMM 'de' yyyy",
   "LEVEL": "Nivel",
   "AVAILABLE_LEVELS_ONLY": "Mostrar sólo niveles disponibles",
   "HELP_IN_FINDING_NEW_LEVELS": "He agregado todos los niveles que pude encontrar. Apreciaría cualquier ayuda para encontrar el resto.",

--- a/src/pages/PageBonusLevel.tsx
+++ b/src/pages/PageBonusLevel.tsx
@@ -51,10 +51,6 @@ function getDatesFromId(id: string) {
   return { startDate };
 }
 
-const formatDate = (date: Date) => {
-  return format(date, "MMMM d, yyyy");
-};
-
 // Function to find the previous level
 function findPreviousLevel(
   currentLevelKey: string,
@@ -133,8 +129,9 @@ const PageBonusLevel = () => {
 
   const { startDate } = getDatesFromId(id);
 
-  const weekOfDate = formatDate(startDate);
-
+  // Format dates for display and ID
+  const dateFormat = t("DATE_FORMAT", "MMMM d, yyyy");
+  const weekOfDate = format(startDate, dateFormat);
   return (
     <RootLayout>
       <PageTitle

--- a/src/pages/PageBonusLevelsList.tsx
+++ b/src/pages/PageBonusLevelsList.tsx
@@ -27,8 +27,9 @@ const PageBonusLevelsList = () => {
     const dateStr = key.replace("level", "");
     const startDate = parse(dateStr, "yyyyMMdd", new Date());
 
-    const weekOfDate = format(startDate, "MMM d, yyyy");
-
+    const dateFormat = t("DATE_FORMAT", "MMM d, yyyy");
+    
+    const weekOfDate = format(startDate, dateFormat);
     // Format dates for display and ID
     const displayRange = t("WEEK_OF", { weekOfDate });
     const id = bonusLevels[key as keyof typeof bonusLevels].path;


### PR DESCRIPTION
To solve the date format problem, I've added a new term to the i18n dictionary with a generic alternative. 

If the format is correct in the interface language, there's no need to change it. If the format is like Spanish, which isn't the correct one, simply adding the correct format to the dictionary entry solves the problem... 

With one caveat: you have to be very clear about how to format the text... DD/MM/YYYY would crash the game, due to dd/MM/yyyy is the correct format... 

I don't know what you think about this solution...