### PR TITLE
Increase supported board size and regions to 15 (A-O) with 15 unique colors

### DIFF
--- a/src/components/LevelBuilder/LevelBuilder.jsx
+++ b/src/components/LevelBuilder/LevelBuilder.jsx
@@ -106,7 +106,7 @@ const LevelBuilder = () => {
     []
   );
 
-  const regionKeys = "ABCDEFGHIJK".slice(0, boardSize);
+  const regionKeys = "ABCDEFGHIJKLMNO".slice(0, boardSize);
   const initialRegionColors = {
     A: lightWisteria,
     B: chardonnay,
@@ -119,6 +119,10 @@ const LevelBuilder = () => {
     I: lightOrchid,
     J: halfBaked,
     K: turquoiseBlue,
+    L: feijoa,
+    M: carnation,
+    N: canCan,
+    O: coldPurple,
   };
 
   const [regionColors, setRegionColors] = useState(
@@ -152,12 +156,12 @@ const LevelBuilder = () => {
   };
 
   const handleBoardSizeChange = (newSize) => {
-    if (newSize > 11 || newSize < 6) return;
+    if (newSize > 15 || newSize < 6) return;
     setBoardSize(newSize);
     setBoard(createInitialBoardForBuilder(newSize));
 
     // Update the regions when board size changes
-    const updatedRegionKeys = "ABCDEFGHIJK".slice(0, newSize);
+    const updatedRegionKeys = "ABCDEFGHIJKLMNO".slice(0, newSize);
     setRegionColors(
       Object.fromEntries(
         updatedRegionKeys


### PR DESCRIPTION
This commit extends the LevelBuilder component to support up to 15 regions (A to O) and 15 distinct colors.  
- The maximum board size is now 15, with dynamic region key handling up to 'O'.
- Added initial colors for all 15 regions.
- Color selection, validation, and display logic are now fully scalable up to 15 distinct areas.
- All related validation and region management functions have been updated accordingly. This enhancement enables the creation of larger, more complex boards for advanced level designs.


There is upgrade possible, such as putting the list of the letters (ABCDEFGHIKJLMNO) or the min/max size of the board as const, but i didn't change it.

Please tell me what you think of it, and if it's good